### PR TITLE
GitHub経由の認証が済むまでは、/user を見られないように変更（長文の説明書つきです：ご注意を）

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,32 +5,72 @@ var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 var helmet = require('helmet');
-var session = require('express-session');
-var passport = require('passport');
-var GitHubStrategy = require('passport-github2').Strategy;
 
-var GITHUB_CLIENT_ID = 'f756acb8748f85e2014b';
-var GITHUB_CLIENT_SECRET = '0fc57f6660bd5da78873eeacda8c131859b64f30';
+//モジュールを読み込む
+var session = require('express-session');     //理解できた＝セッションを維持するためのもの
+var passport = require('passport');     //理解できた＝パスポートは、オース（認証本部）の基盤みたいなもの
+
+
+//var GitHubStrategy = require('passport-github2').Strategy;
+var passportGithub2 = require('passport-github2');  var GitHubStrategy = passportGithub2.Strategy
+//前まで使っていたスタイルに書き換えてみました。（なお、関数名にマイナスが入ると計算しちゃうので、キャメル形式を採用しました）
+//なんだコレ？？？？？？？？？   //モジュール自体は、ギットハブは、パスポートをギットハブに適応させるものだが、ストラテジ（戦略）を、この表現にするのが初体験なので調べましょう！！！
+//clientIDとclientSecretと,callbackURLの３つは用意しておくことになっている。 //テキストに書いてあるＵＲＬ先で公式（Passport-GitHub2）のを読めば、このモジュールの使い方のサンプルがあるので、そちらを参照！！
+//ここのところで、今まで通りに書いてみると、 var passport-github2 = require('passport-github2');  var GitHubStrategy = passport-github2.Strategy  　で動くかどうか、実験してみたい。！！！
+
+//GitHub で準備しておいたトークンを定数として登録
+var GITHUB_CLIENT_ID = '90d1f8bc7a717541e85b';
+var GITHUB_CLIENT_SECRET = '10f61df0d616f4ee70a43a8170f4e470dc83f8be';
+//  GITHUB_CLIENT_IDとGITHUB_CLIENT_SECRETは、自前のものに交換しました。
+
+//パスポートの使い方は、http://knimon-software.github.io/www.passportjs.org/guide/ node.js用認証モジュール Passport（日本語版:非公式）が、日本語で書いてあるので、そちらを俯瞰してから、英語のほうで細部を確認しよう。
+//バイナリ情報として保存？？？
+
+//公式？　https://github.com/cfsghost/passport-github/blob/master/examples/login/app.js   のサンプルのコメント
+
+// Passport session setup.
+//   To support persistent login sessions, Passport needs to be able to
+//   serialize users into and deserialize users out of the session.  Typically,
+//   this will be as simple as storing the user ID when serializing, and finding
+//   the user by ID when deserializing.  However, since this example does not
+//   have a database of user records, the complete GitHub profile is serialized
+//   and deserialized.
 
 passport.serializeUser(function (user, done) {
-  done(null, user);
+  done(null, user);     //ダーン関数の、１番目の引数はエラーだった時のため。第２引数は、結果？？？？？？
 });
+//（引用）「ユーザオブジェクトを与えてやるから，保存に成功したらdoneの第2引数ででユーザIーを渡してくれ．エラーがあったときは第1引数にそれを渡してくれ．続く処理は俺(Passport)がやるからとりあえずその仕事だけよろしく．」 
 
 passport.deserializeUser(function (obj, done) {
   done(null, obj);
 });
+//（引用）
+//上の２つのシリアライズと、デシリアライズの部分は、セッションを管理しているらしい。
+//多分、こいつを見れば、ドンピシャリと解決しそう！！！    https://teratail.com/questions/50461
 
+
+
+// ここも公式らしきサイトのサンプルのコメントを貼り付け
+// Use the GitHubStrategy within Passport.
+//   Strategies in Passport require a `verify` function, which accept
+//   credentials (in this case, an accessToken, refreshToken, and GitHub
+//   profile), and invoke a callback with a user object.
 passport.use(new GitHubStrategy({
   clientID: GITHUB_CLIENT_ID,
   clientSecret: GITHUB_CLIENT_SECRET,
   callbackURL: 'http://localhost:8000/auth/github/callback'
 },
-  function (accessToken, refreshToken, profile, done) {
-    process.nextTick(function () {
+  function (accessToken, refreshToken, profile, done) {           //実際に認証する処理らしい？？？？
+    process.nextTick(function () {                              //ネクスティックは、ループした時に待機？？？？？
       return done(null, profile);
     });
   }
   ));
+
+//  ここまでで、パスポートの導入（設定）が済んだような気がする
+//  done関数、process.nextTick 関数  等などは、コールバック　や　非同期　といった、核心的な部分を理解しなければならない。（逆に言えば、今回の学習で、その辺りを少し理解できる良い機会でもある。）
+
+
 
 var routes = require('./routes/index');
 var users = require('./routes/users');
@@ -51,33 +91,64 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
+
+// configure Express
+// Initialize Passport!  Also use passport.session() middleware, to support
+// persistent login sessions (recommended).
 app.use(session({ secret: '417cce55dcfcfaeb', resave: false, saveUninitialized: false }));
 app.use(passport.initialize());
 app.use(passport.session());
 
 app.use('/', routes);
-app.use('/users', users);
+app.use('/users', ensureAuthenticated, users);
 app.use('/photos', photos);
 
+
+// GET /auth/github
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  The first step in GitHub authentication will involve redirecting
+//   the user to github.com.  After authorization, GitHub will redirect the user
+//   back to this application at /auth/github/callback
 app.get('/auth/github',
   passport.authenticate('github', { scope: ['user:email'] }),
   function (req, res) {
+        // The request will be redirected to GitHub for authentication, so this
+        // function will not be called.
   });
 
+
+// GET /auth/github/callback
+//   Use passport.authenticate() as route middleware to authenticate the
+//   request.  If authentication fails, the user will be redirected back to the
+//   login page.  Otherwise, the primary route function will be called,
+//   which, in this example, will redirect the user to the home page.
 app.get('/auth/github/callback',
   passport.authenticate('github', { failureRedirect: '/login' }),
   function (req, res) {
     res.redirect('/');
   });
 
+//    以下は、/login に GET でアクセスがあった時に、 login.jade というテンプレートがあることを前提にログインページを描画するコード
 app.get('/login', function (req, res) {
   res.render('login', { user: req.user });
 });
 
+//    以下のコードは、/logout に GET でアクセスがあった時にログアウトを実施し、 / のドキュメントルートにリダイレクトさせる
 app.get('/logout', function (req, res) {
   req.logout();
   res.redirect('/');
 });
+
+// Simple route middleware to ensure user is authenticated.
+//   Use this route middleware on any resource that needs to be protected.  If
+//   the request is authenticated (typically via a persistent login session),
+//   the request will proceed.  Otherwise, the user will be redirected to the
+//   login page.
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) { return next(); }
+  res.redirect('/login')
+}
+
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,7 +3,7 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-  res.render('index', { title: 'Express', user: req.user });
+  res.render('index', { title: 'Express', user: req.user });      //req.user というオブジェクトにユーザー情報が含まれているので、それをそのまま、テンプレートの user というプロパティに含めるように変更
 });
 
 module.exports = router;

--- a/views/index.jade
+++ b/views/index.jade
@@ -1,5 +1,5 @@
 extends layout
-
+//ここでも、 extends を使って　layout を使いまわしている   https://pugjs.org/language/extends.html  を参照しましょうね。
 block content
   h1= title
   p Welcome to #{title}

--- a/views/login.jade
+++ b/views/login.jade
@@ -1,4 +1,4 @@
 extends layout
-
+// https://pugjs.org/language/extends.html を読みましょうね。
 block content
   a(href="/auth/github") Login with GitHub


### PR DESCRIPTION
練習用なのでマージは不要です。

今回の授業から早速に運営コメントをバージョンアップしていただきまして、ありがとうございます。（ニコ生アンケートで、１を１００％にしたいです。）

コメント行が大変なことになっていて、とても、汚いです。見ないほうが良いかもしれません・・・。
今回は、授業がとても難しかったので、色々と調べまわっていたら頭が混乱してきまして・・・。（言い訳です。）
こうやって勉強している人もいるという参考程度で・・・。（繰り返しますが、言い訳です。）

なお、コメント行と練習問題以外の場所で、２点ほど変更しました。
・クライアント・ＩＤと、クライアント・シークレットを自前のものに置き換えました。
・var GitHubStrategy = require('passport-github2').Strategy;　の部分を今までやっていたように２段階に分けてモジュールを読み込む方策に書き換えました。（公式の原文サンプルなのは、passport のあとにマイナスが付いているからではないかと推測しました。もちろん、サンプルの方が、簡潔でスマートだとは思います。）

ネクスティックは、今回の私の勉強方法で例えてみます。
難しい行が来たら少し調べ、そこで時間を浪費しすぎないようにするために、次の行へ。
それが済んだら、難しい行に戻って、時間がかかるようであれば、次の次の行へ・・・（以下ループ）
といった感じかなと、現状では、思っています。

　外部認証だと、ログイン情報を自分で抱えないのでより安全。さらに、自分で実装するより、ギットハブやツイッターの方がプロなので、より万全なログイン認証がしっかりと管理されている。などが利点だと思います。
　しかし、GitHubのログインのIDとパスワードをのっとられたら、そこに連鎖しているサービスも、芋づる式にのっとられるという危惧が、ほんの少しあると思いました。
　ですが、プロが突破されるような攻撃だと、アマチュアの個人の認証機能の実装など、いとも容易く突破されるとも思いますので、やはり、外部認証のほうが良さそうです。