### PR TITLE
認証が済んでいない状態で/usersにアクセスした場合、/loginにリダイレクトするようにした

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 app.use('/', indexRouter);
-app.use('/users', usersRouter);
+app.use('/users', ensureAuthenticated, usersRouter);
 app.use('/photos', photosRouter);
 
 app.get('/auth/github',
@@ -75,6 +75,13 @@ app.get('/logout', function (req, res) {
   req.logout();
   res.redirect('/');
 });
+
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) {
+    return next();
+  }
+  res.redirect('/login');
+};
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {


### PR DESCRIPTION
GitHubを用いた認証が済んでいないとき、/usersにアクセスすると/loginにリダイレクトして認証を促すようにした。